### PR TITLE
feat: accept zip files in file loader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "iof-list-manipulator",
       "version": "0.0.1",
+      "dependencies": {
+        "fflate": "0.8.2"
+      },
       "devDependencies": {
         "@eslint/js": "10.0.1",
         "@sveltejs/adapter-static": "^3.0.6",
@@ -2427,6 +2430,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
     "typescript-eslint": "^8.30.1",
     "vite": "^8.0.0",
     "vitest": "^4.0.0"
+  },
+  "dependencies": {
+    "fflate": "0.8.2"
   }
 }

--- a/src/lib/components/FileLoader.svelte
+++ b/src/lib/components/FileLoader.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { unzipSync } from 'fflate';
 	import { parseResultList } from '$lib/iof/parse.js';
 	import { appState } from '$lib/state.svelte.js';
 
@@ -11,17 +12,47 @@
 	let inputEl: HTMLInputElement;
 	let dragOver = $state(false);
 
+	function parseXml(xml: string) {
+		try {
+			appState.setResultList(parseResultList(xml));
+		} catch (e) {
+			appState.setParseError(e instanceof Error ? e.message : String(e));
+		}
+	}
+
 	function loadFile(file: File) {
-		const reader = new FileReader();
-		reader.onload = () => {
-			try {
-				appState.setResultList(parseResultList(reader.result as string));
-			} catch (e) {
-				appState.setParseError(e instanceof Error ? e.message : String(e));
-			}
-			inputEl.value = '';
-		};
-		reader.readAsText(file);
+		const isZip =
+			file.name.endsWith('.zip') ||
+			file.type === 'application/zip' ||
+			file.type === 'application/x-zip-compressed';
+
+		if (isZip) {
+			const reader = new FileReader();
+			reader.onload = () => {
+				try {
+					const data = new Uint8Array(reader.result as ArrayBuffer);
+					const entries = unzipSync(data);
+					const xmlKey = Object.keys(entries).find((k) => k.toLowerCase().endsWith('.xml'));
+					if (!xmlKey) {
+						appState.setParseError('No .xml file found inside the zip archive.');
+						return;
+					}
+					const decoder = new TextDecoder();
+					parseXml(decoder.decode(entries[xmlKey]));
+				} catch (e) {
+					appState.setParseError(e instanceof Error ? e.message : String(e));
+				}
+				inputEl.value = '';
+			};
+			reader.readAsArrayBuffer(file);
+		} else {
+			const reader = new FileReader();
+			reader.onload = () => {
+				parseXml(reader.result as string);
+				inputEl.value = '';
+			};
+			reader.readAsText(file);
+		}
 	}
 
 	function handleChange(e: Event) {
@@ -41,7 +72,7 @@
 <input
 	bind:this={inputEl}
 	type="file"
-	accept=".xml,application/xml,text/xml"
+	accept=".xml,.zip,application/xml,text/xml,application/zip,application/x-zip-compressed"
 	style="display:none"
 	tabindex="-1"
 	onchange={handleChange}
@@ -75,7 +106,7 @@
 				{dragOver ? 'Drop to load' : 'Load IOF XML result list'}
 			</p>
 			<p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
-				Click to browse, or drag and drop a <code class="font-mono">.xml</code> file
+				Click to browse, or drag and drop a <code class="font-mono">.xml</code> or <code class="font-mono">.zip</code> file
 			</p>
 		</div>
 	</button>


### PR DESCRIPTION
Closes #33

## Changes
- Install `fflate` (browser-compatible zip library) for in-browser zip extraction
- When a `.zip` file is loaded (via browse or drag-and-drop), extract the first `.xml` entry and parse it
- Update file input `accept` attribute to include zip MIME types
- Update landing zone description to mention `.zip` alongside `.xml`