### PR TITLE
feat: remove control from individual race class

### DIFF
--- a/src/lib/components/ClassResultPanel.svelte
+++ b/src/lib/components/ClassResultPanel.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { ClassResult } from '$lib/iof/types.js';
 	import { appState } from '$lib/state.svelte.js';
-	import { recalcPositions } from '$lib/utils.js';
+	import { recalcPositions, removeControlFromResults } from '$lib/utils.js';
 	import PersonResultRow from './PersonResultRow.svelte';
 	import TeamResultPanel from './TeamResultPanel.svelte';
 
@@ -14,6 +14,15 @@
 
 	const course = $derived(cr.courses[0]);
 	const isRelay = $derived(cr.teamResults.length > 0);
+
+	/** Ordered list of unique control codes across all competitors' split times (course order). */
+	const courseControls = $derived(
+		isRelay
+			? []
+			: cr.personResults
+					.flatMap((pr) => pr.results.flatMap((r) => r.splitTimes.map((st) => st.controlCode)))
+					.filter((code, i, arr) => arr.indexOf(code) === i)
+	);
 
 	function addRunner() {
 		const rl = appState.resultList;
@@ -40,6 +49,26 @@
 		if (!rl) return;
 		if (!confirm(`Remove class "${cr.class.name}" and all its results?`)) return;
 		rl.classResults.splice(classIndex, 1);
+		appState.markDirty();
+	}
+
+	function removeControl(controlCode: string) {
+		const rl = appState.resultList;
+		if (!rl) return;
+		const order = courseControls;
+		const pos = order.indexOf(controlCode);
+		const prevCode = pos > 0 ? order[pos - 1] : 'start';
+		const nextCode = pos < order.length - 1 ? order[pos + 1] : 'finish';
+		if (
+			!confirm(
+				`Remove control ${controlCode} from class "${cr.class.name}"?\n\n` +
+					`The leg time from ${prevCode} to ${nextCode} will be set to 0 for all competitors.`
+			)
+		)
+			return;
+		const allResults = rl.classResults[classIndex].personResults.flatMap((pr) => pr.results);
+		removeControlFromResults(allResults, order, controlCode);
+		recalcPositions(allResults);
 		appState.markDirty();
 	}
 
@@ -173,6 +202,22 @@
 			<span class="text-xs text-gray-400 dark:text-slate-500">
 				{cr.personResults.length + cr.teamResults.length} entries
 			</span>
+			{#if !isRelay && courseControls.length > 0}
+				<select
+					aria-label="Remove a control from class {cr.class.name}"
+					onchange={(e) => {
+						const code = (e.target as HTMLSelectElement).value;
+						if (code) removeControl(code);
+						(e.target as HTMLSelectElement).value = '';
+					}}
+					class="rounded border border-gray-200 bg-white px-1.5 py-0.5 text-xs text-gray-600 hover:border-orange-300 focus:outline-none dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300"
+				>
+					<option value="">Remove control…</option>
+					{#each courseControls as code (code)}
+						<option value={code}>{code}</option>
+					{/each}
+				</select>
+			{/if}
 			<button
 				type="button"
 				onclick={removeClassResult}

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import { removeControlFromResults } from './utils.js';
+
+// Helper to build a minimal race result for testing
+function makeResult(splits: { code: string; time: number }[], totalTime?: number) {
+	return {
+		time: totalTime,
+		splitTimes: splits.map((s) => ({ controlCode: s.code, time: s.time }))
+	};
+}
+
+describe('removeControlFromResults', () => {
+	// Course: start(0) → 1(60s) → 2(130s) → 3(210s) → finish(300s)
+	const courseOrder = ['1', '2', '3'];
+
+	it('removes middle control and zeroes the 1→3 leg for each competitor', () => {
+		// Removing '2': prevTime=t1=60, nextTime=t3=210, legTime=150
+		const result = makeResult(
+			[
+				{ code: '1', time: 60 },
+				{ code: '2', time: 130 },
+				{ code: '3', time: 210 }
+			],
+			300
+		);
+
+		removeControlFromResults([result], courseOrder, '2');
+
+		// split for '2' removed; '3' shifted by -150 → 210-150=60
+		expect(result.splitTimes.map((s) => s.controlCode)).toEqual(['1', '3']);
+		expect(result.splitTimes.find((s) => s.controlCode === '3')?.time).toBe(60);
+		// total: 300 - 150 = 150
+		expect(result.time).toBe(150);
+	});
+
+	it('handles competitor missing the removed control split', () => {
+		// No split for '2'; still uses t1=60 and t3=210 → legTime=150
+		const result = makeResult(
+			[
+				{ code: '1', time: 60 },
+				{ code: '3', time: 210 }
+			],
+			300
+		);
+
+		removeControlFromResults([result], courseOrder, '2');
+
+		expect(result.splitTimes.map((s) => s.controlCode)).toEqual(['1', '3']);
+		expect(result.splitTimes.find((s) => s.controlCode === '3')?.time).toBe(60);
+		expect(result.time).toBe(150);
+	});
+
+	it('removes first control (no prev → prevTime=0)', () => {
+		// Remove '1': prevTime=0, nextTime=t2=130, legTime=130
+		const result = makeResult(
+			[
+				{ code: '1', time: 60 },
+				{ code: '2', time: 130 },
+				{ code: '3', time: 210 }
+			],
+			300
+		);
+
+		removeControlFromResults([result], courseOrder, '1');
+
+		expect(result.splitTimes.map((s) => s.controlCode)).toEqual(['2', '3']);
+		// '2' shifted by -130 → 0; '3' shifted by -130 → 80
+		expect(result.splitTimes.find((s) => s.controlCode === '2')?.time).toBe(0);
+		expect(result.splitTimes.find((s) => s.controlCode === '3')?.time).toBe(80);
+		// total: 300 - 130 = 170
+		expect(result.time).toBe(170);
+	});
+
+	it('removes last control (no next → nextTime=total)', () => {
+		// Remove '3': prevTime=t2=130, nextTime=total=300, legTime=170
+		const result = makeResult(
+			[
+				{ code: '1', time: 60 },
+				{ code: '2', time: 130 },
+				{ code: '3', time: 210 }
+			],
+			300
+		);
+
+		removeControlFromResults([result], courseOrder, '3');
+
+		expect(result.splitTimes.map((s) => s.controlCode)).toEqual(['1', '2']);
+		// splits before '3' unchanged
+		expect(result.splitTimes.find((s) => s.controlCode === '2')?.time).toBe(130);
+		// total: 300 - 170 = 130
+		expect(result.time).toBe(130);
+	});
+
+	it('applies per-competitor leg times independently across multiple results', () => {
+		// r1: t1=60, t3=210 → legTime=150 → total 300-150=150
+		const r1 = makeResult(
+			[
+				{ code: '1', time: 60 },
+				{ code: '2', time: 130 },
+				{ code: '3', time: 210 }
+			],
+			300
+		);
+		// r2: t1=80, t3=250 → legTime=170 → total 360-170=190
+		const r2 = makeResult(
+			[
+				{ code: '1', time: 80 },
+				{ code: '2', time: 160 },
+				{ code: '3', time: 250 }
+			],
+			360
+		);
+
+		removeControlFromResults([r1, r2], courseOrder, '2');
+
+		expect(r1.time).toBe(150);
+		expect(r1.splitTimes.find((s) => s.controlCode === '3')?.time).toBe(60);
+
+		expect(r2.time).toBe(190);
+		expect(r2.splitTimes.find((s) => s.controlCode === '3')?.time).toBe(80);
+	});
+});

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -90,3 +90,68 @@ export function recalcPositions(
 		r.timeBehind = winnerTime !== undefined ? (r.time ?? 0) - winnerTime : undefined;
 	}
 }
+
+/**
+ * Remove a control from every result in a class, setting the leg time
+ * between the preceding and following control to zero for all competitors.
+ *
+ * Split times are cumulative elapsed times from start. Removing controlCode
+ * subtracts (nextSplit.time − prevSplit.time) from the total and from all
+ * subsequent split times, then deletes the split for controlCode.
+ *
+ * @param results    All PersonRaceResults in the class (mutated in place)
+ * @param courseOrder  Control codes in course order (used to find prev/next)
+ * @param controlCode  The control to remove
+ */
+export function removeControlFromResults(
+	results: Array<{
+		time?: number;
+		splitTimes: Array<{ controlCode: string; time?: number }>;
+	}>,
+	courseOrder: string[],
+	controlCode: string
+) {
+	const pos = courseOrder.indexOf(controlCode);
+	const prevCode = pos > 0 ? courseOrder[pos - 1] : null;
+	const nextCode = pos < courseOrder.length - 1 ? courseOrder[pos + 1] : null;
+
+	for (const result of results) {
+		const splits = result.splitTimes;
+
+		// Cumulative time of the preceding control (0 = start)
+		const prevTime =
+			prevCode !== null ? (splits.find((s) => s.controlCode === prevCode)?.time ?? 0) : 0;
+
+		// Cumulative time of the following control (fall back to finish time)
+		const nextTime =
+			nextCode !== null
+				? (splits.find((s) => s.controlCode === nextCode)?.time ?? result.time)
+				: result.time;
+
+		const legTime =
+			prevTime !== undefined && nextTime !== undefined ? nextTime - prevTime : undefined;
+
+		// Remove the split for the eliminated control
+		const removedIdx = splits.findIndex((s) => s.controlCode === controlCode);
+		if (removedIdx !== -1) splits.splice(removedIdx, 1);
+
+		if (legTime === undefined || legTime <= 0) continue;
+
+		// Shift all cumulative split times that come after the removed control
+		// (i.e., those at or beyond the next control's original position in course order)
+		if (nextCode !== null) {
+			const nextCourseIdx = courseOrder.indexOf(nextCode);
+			for (const s of splits) {
+				const idx = courseOrder.indexOf(s.controlCode);
+				if (idx >= nextCourseIdx && s.time !== undefined) {
+					s.time = Math.max(0, s.time - legTime);
+				}
+			}
+		}
+
+		// Subtract from total time
+		if (result.time !== undefined) {
+			result.time = Math.max(0, result.time - legTime);
+		}
+	}
+}


### PR DESCRIPTION
Closes #7

When a punch device fails, this feature removes a control from the class and sets the leg time between the preceding and following control to zero for every competitor (regardless of whether they punched it).

Algorithm per competitor:
- legTime = nextSplit.time - prevSplit.time (prevSplit.time = 0 at start)
- Remove the split for the eliminated control (if present)
- Shift all subsequent cumulative split times down by legTime
- Subtract legTime from the total race time
- Recalculate positions and time-behind

UI: A 'Remove control...' dropdown in the class header for individual-race classes with split times recorded.

Changes:
- utils.ts: removeControlFromResults() helper
- utils.test.ts: 5 unit tests (middle/first/last control, missing splits, multiple competitors)
- ClassResultPanel.svelte: Remove control dropdown and wiring