### PR TITLE
ci: switch to gh-pages branch deployment with PR previews

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,19 +6,15 @@ on:
       - main
       - master
 
-# Required for the deploy-pages action
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
-# Only one deployment at a time; cancel any in-progress run
 concurrency:
-  group: pages
+  group: deploy-main
   cancel-in-progress: true
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -28,29 +24,19 @@ jobs:
           node-version: 24
           cache: npm
 
-      # Detects the repo base path (e.g. /iof-list-manipulator) automatically
-      - uses: actions/configure-pages@v6
-        id: pages
-
       - name: Install dependencies
         run: npm ci
 
       - name: Build
         run: npm run build
         env:
-          BASE_PATH: ${{ steps.pages.outputs.base_path }}
+          BASE_PATH: /iof-list-manipulator
 
-      - uses: actions/upload-pages-artifact@v5
+      - name: Deploy to gh-pages
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          path: build/
-
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy
-        id: deployment
-        uses: actions/deploy-pages@v5
+          branch: gh-pages
+          folder: build
+          clean: true
+          clean-exclude: |
+            pr-*/

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -32,6 +32,12 @@ jobs:
         env:
           BASE_PATH: /iof-list-manipulator/pr-${{ github.event.pull_request.number }}
 
+      # GitHub Pages serves 404.html for unmatched paths site-wide, so the
+      # root 404.html (production build) would be served instead of the preview.
+      # Adding index.html lets GitHub Pages find the preview as a directory index.
+      - name: Add index.html for subdirectory routing
+        run: cp build/404.html build/index.html
+
       - name: Deploy preview to gh-pages
         uses: JamesIves/github-pages-deploy-action@v4
         with:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,78 @@
+name: PR Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-preview:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build preview
+        run: npm run build
+        env:
+          BASE_PATH: /iof-list-manipulator/pr-${{ github.event.pull_request.number }}
+
+      - name: Deploy preview to gh-pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: build
+          target-folder: pr-${{ github.event.pull_request.number }}
+          clean: false
+
+      - name: Post preview URL comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          message: |
+            ## 🚀 Preview deployment
+
+            | | |
+            |---|---|
+            | **URL** | https://mikaello.github.io/iof-list-manipulator/pr-${{ github.event.pull_request.number }}/ |
+            | **Commit** | ${{ github.event.pull_request.head.sha }} |
+
+            _Deployed by [PR Preview](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})_
+
+  cleanup-preview:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+
+      - name: Remove preview folder
+        run: |
+          if [ -d "pr-${{ github.event.pull_request.number }}" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git rm -rf pr-${{ github.event.pull_request.number }}/
+            git commit -m "chore: remove preview for PR #${{ github.event.pull_request.number }}"
+            git push
+          fi
+
+      - name: Update comment on PR close
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          message: |
+            Preview deployment removed (PR closed).


### PR DESCRIPTION
## What

Replaces the `actions/deploy-pages` approach with `JamesIves/github-pages-deploy-action` pushing to a `gh-pages` branch, and adds a PR preview workflow.

## Why

The GitHub Actions Pages deployment source only supports a single live deployment. To get per-PR preview URLs, we need a `gh-pages` branch where each PR gets its own subfolder.

## How it works

**Production** (`deploy.yml`):
- Triggers on push to `main`
- Builds with `BASE_PATH=/iof-list-manipulator`
- Deploys to root of `gh-pages` branch, preserving `pr-*/` subfolders

**PR Preview** (`preview.yml`):
- Triggers on PR open/update: builds with `BASE_PATH=/iof-list-manipulator/pr-{number}`, deploys to `gh-pages/pr-{number}/`, posts a sticky comment with the preview URL
- Triggers on PR close: removes the `pr-{number}/` subfolder and updates the comment

## Already done (before this PR)

- Created `gh-pages` branch with the current production build
- Switched GitHub Pages source from "GitHub Actions" to "gh-pages branch"

The site is already live at https://mikaello.github.io/iof-list-manipulator/ from the `gh-pages` branch. Merging this PR will make future pushes to `main` update it, and all open PRs will get preview deployments on their next push.