### PR TITLE
feat: course controls — algorithm, editor popover, move validation

### DIFF
--- a/src/lib/components/ClassControlsPopover.svelte
+++ b/src/lib/components/ClassControlsPopover.svelte
@@ -1,0 +1,209 @@
+<script lang="ts">
+	import type { ClassResult } from '$lib/iof/types.js';
+	import { getClassControls, setClassControls } from '$lib/iof/classControls.js';
+	import { appState } from '$lib/state.svelte.js';
+
+	interface Props {
+		classResult: ClassResult;
+		classIndex: number;
+	}
+
+	const { classResult: cr, classIndex }: Props = $props();
+
+	let open = $state(false);
+	let popoverEl: HTMLDivElement | undefined = $state();
+
+	const classControls = $derived(getClassControls(cr));
+
+	/** Local editable copy of the control list, refreshed each time the popover opens. */
+	let editControls = $state<string[]>([]);
+	let newCode = $state('');
+
+	function openPopover() {
+		editControls = classControls ? [...classControls.controls] : [];
+		newCode = '';
+		open = true;
+	}
+
+	function close() {
+		open = false;
+	}
+
+	function onClickOutside(e: MouseEvent) {
+		if (popoverEl && !popoverEl.contains(e.target as Node)) close();
+	}
+
+	$effect(() => {
+		if (open) {
+			window.addEventListener('mousedown', onClickOutside);
+			return () => window.removeEventListener('mousedown', onClickOutside);
+		}
+	});
+
+	function moveUp(i: number) {
+		if (i === 0) return;
+		[editControls[i - 1], editControls[i]] = [editControls[i], editControls[i - 1]];
+	}
+
+	function moveDown(i: number) {
+		if (i >= editControls.length - 1) return;
+		[editControls[i], editControls[i + 1]] = [editControls[i + 1], editControls[i]];
+	}
+
+	function removeControl(i: number) {
+		editControls.splice(i, 1);
+	}
+
+	function addControl() {
+		const code = newCode.trim();
+		if (!code) return;
+		editControls.push(code);
+		newCode = '';
+	}
+
+	function save() {
+		const rl = appState.resultList;
+		if (!rl) return;
+		setClassControls(rl.classResults[classIndex], [...editControls]);
+		appState.markDirty();
+		close();
+	}
+
+	const sourceLabel = $derived(
+		classControls?.source === 'course' ? 'Explicit (CourseControl)' : 'Inferred from splits'
+	);
+</script>
+
+<div class="relative inline-block">
+	<button
+		type="button"
+		onclick={openPopover}
+		title="View / edit course controls"
+		aria-expanded={open}
+		aria-haspopup="dialog"
+		class="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium transition-colors
+			{classControls
+				? 'text-indigo-500 hover:bg-indigo-50 hover:text-indigo-700 dark:text-indigo-400 dark:hover:bg-indigo-950/40'
+				: 'text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:text-slate-500 dark:hover:bg-slate-700'}
+			focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+	>
+		<svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+			<path stroke-linecap="round" stroke-linejoin="round" d="M9 6.75V15m6-6v8.25m.503 3.498 4.875-2.437c.381-.19.622-.58.622-1.006V4.82c0-.836-.88-1.38-1.628-1.006l-3.869 1.934c-.317.159-.69.159-1.006 0L9.503 3.252a1.125 1.125 0 0 0-1.006 0L3.622 5.689C3.24 5.88 3 6.27 3 6.695V19.18c0 .836.88 1.38 1.628 1.006l3.869-1.934c.317-.159.69-.159 1.006 0l4.994 2.497c.317.159.69.159 1.006 0Z" />
+		</svg>
+		{#if classControls}
+			{classControls.controls.length}
+		{:else}
+			?
+		{/if}
+	</button>
+
+	{#if open}
+		<div
+			role="dialog"
+			aria-label="Course controls for class {cr.class.name}"
+			bind:this={popoverEl}
+			onkeydown={(e) => e.key === 'Escape' && close()}
+			class="absolute left-0 top-full z-50 mt-1 w-72 rounded-xl border border-gray-200 bg-white p-4 shadow-xl dark:border-slate-700 dark:bg-slate-900"
+		>
+			<!-- Header -->
+			<div class="mb-3 flex items-center justify-between">
+				<span class="text-sm font-semibold text-gray-800 dark:text-gray-100">Course controls</span>
+				<button
+					type="button"
+					onclick={close}
+					aria-label="Close"
+					class="rounded p-0.5 text-gray-400 hover:text-gray-600 dark:text-slate-500 dark:hover:text-slate-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+				>
+					<svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" /></svg>
+				</button>
+			</div>
+
+			<!-- Source badge -->
+			{#if classControls}
+				<p class="mb-3 text-xs text-gray-500 dark:text-slate-400">
+					Source: <span class="font-medium text-gray-700 dark:text-slate-200">{sourceLabel}</span>
+				</p>
+			{:else}
+				<p class="mb-3 text-xs text-amber-600 dark:text-amber-400">No controls found — add them below.</p>
+			{/if}
+
+			<!-- Control list -->
+			<ol class="mb-3 space-y-1">
+				{#each editControls as code, i (i)}
+					<li class="flex items-center gap-1">
+						<span class="w-5 text-right text-xs text-gray-400 dark:text-slate-500 tabular-nums">{i + 1}.</span>
+						<input
+							type="text"
+							bind:value={editControls[i]}
+							aria-label="Control {i + 1} code"
+							class="w-16 rounded border border-gray-200 bg-transparent px-1.5 py-0.5 text-sm font-mono text-gray-800 focus:border-indigo-400 focus:outline-none dark:border-slate-600 dark:text-gray-100 dark:focus:border-indigo-500"
+						/>
+						<button
+							type="button"
+							onclick={() => moveUp(i)}
+							disabled={i === 0}
+							aria-label="Move control {i + 1} up"
+							class="rounded p-0.5 text-gray-400 hover:text-gray-600 disabled:opacity-30 dark:text-slate-500 dark:hover:text-slate-300 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-indigo-500"
+						>
+							<svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 15.75 7.5-7.5 7.5 7.5" /></svg>
+						</button>
+						<button
+							type="button"
+							onclick={() => moveDown(i)}
+							disabled={i === editControls.length - 1}
+							aria-label="Move control {i + 1} down"
+							class="rounded p-0.5 text-gray-400 hover:text-gray-600 disabled:opacity-30 dark:text-slate-500 dark:hover:text-slate-300 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-indigo-500"
+						>
+							<svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" /></svg>
+						</button>
+						<button
+							type="button"
+							onclick={() => removeControl(i)}
+							aria-label="Remove control {code}"
+							class="ml-auto rounded p-0.5 text-red-400 hover:text-red-600 dark:text-red-500 dark:hover:text-red-400 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-red-500"
+						>
+							<svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" /></svg>
+						</button>
+					</li>
+				{/each}
+			</ol>
+
+			<!-- Add control -->
+			<div class="mb-4 flex gap-1">
+				<input
+					type="text"
+					bind:value={newCode}
+					placeholder="Code"
+					aria-label="New control code"
+					onkeydown={(e) => e.key === 'Enter' && addControl()}
+					class="w-20 rounded border border-gray-200 bg-transparent px-1.5 py-1 text-sm font-mono text-gray-800 focus:border-indigo-400 focus:outline-none dark:border-slate-600 dark:text-gray-100 dark:focus:border-indigo-500"
+				/>
+				<button
+					type="button"
+					onclick={addControl}
+					class="rounded border border-indigo-200 px-2 py-1 text-xs font-medium text-indigo-600 hover:bg-indigo-50 dark:border-indigo-800 dark:text-indigo-400 dark:hover:bg-indigo-950/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+				>
+					+ Add
+				</button>
+			</div>
+
+			<!-- Footer -->
+			<div class="flex justify-end gap-2 border-t border-gray-100 pt-3 dark:border-slate-800">
+				<button
+					type="button"
+					onclick={close}
+					class="rounded px-3 py-1 text-xs font-medium text-gray-500 hover:bg-gray-100 dark:text-slate-400 dark:hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+				>
+					Cancel
+				</button>
+				<button
+					type="button"
+					onclick={save}
+					class="rounded bg-indigo-500 px-3 py-1 text-xs font-medium text-white hover:bg-indigo-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+				>
+					Save
+				</button>
+			</div>
+		</div>
+	{/if}
+</div>

--- a/src/lib/components/ClassControlsPopover.svelte
+++ b/src/lib/components/ClassControlsPopover.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { ClassResult } from '$lib/iof/types.js';
-	import { getClassControls, setClassControls } from '$lib/iof/classControls.js';
+	import { getClassControls, setClassControls, reconcileSplitsForClass } from '$lib/iof/classControls.js';
+	import { recalcPositions, sortPersonResults } from '$lib/utils.js';
 	import { appState } from '$lib/state.svelte.js';
 
 	interface Props {
@@ -64,7 +65,23 @@
 	function save() {
 		const rl = appState.resultList;
 		if (!rl) return;
-		setClassControls(rl.classResults[classIndex], [...editControls]);
+		const cr = rl.classResults[classIndex];
+		setClassControls(cr, [...editControls]);
+
+		// Re-validate every person in the class against the updated control set
+		for (const pr of cr.personResults) {
+			for (const result of pr.results) {
+				const valid = reconcileSplitsForClass(result, editControls);
+				if (valid && result.status === 'MissingPunch') {
+					result.status = 'OK';
+				} else if (!valid && (result.status === 'OK' || result.status === 'Finished')) {
+					result.status = 'MissingPunch';
+				}
+			}
+		}
+
+		recalcPositions(cr.personResults.map((p) => p.results[0]).filter(Boolean));
+		sortPersonResults(cr.personResults);
 		appState.markDirty();
 		close();
 	}

--- a/src/lib/components/ClassResultPanel.svelte
+++ b/src/lib/components/ClassResultPanel.svelte
@@ -4,6 +4,7 @@
 	import { recalcPositions, removeControlFromResults } from '$lib/utils.js';
 	import PersonResultRow from './PersonResultRow.svelte';
 	import TeamResultPanel from './TeamResultPanel.svelte';
+	import ClassControlsPopover from './ClassControlsPopover.svelte';
 
 	interface Props {
 		classResult: ClassResult;
@@ -159,6 +160,9 @@
 				}}
 				class="min-w-0 rounded border border-transparent bg-transparent px-1 py-0.5 text-sm font-semibold text-gray-800 hover:border-gray-300 focus:border-indigo-400 focus:bg-indigo-50/50 focus:outline-none dark:text-gray-100 dark:hover:border-slate-600 dark:focus:border-indigo-500 dark:focus:bg-indigo-950/20"
 			/>
+			{#if !isRelay}
+				<ClassControlsPopover classResult={cr} {classIndex} />
+			{/if}
 		</div>
 
 		{#if course}

--- a/src/lib/components/ClassResultPanel.svelte
+++ b/src/lib/components/ClassResultPanel.svelte
@@ -2,6 +2,7 @@
 	import type { ClassResult } from '$lib/iof/types.js';
 	import { appState } from '$lib/state.svelte.js';
 	import { recalcPositions, removeControlFromResults } from '$lib/utils.js';
+	import { getClassControls, reconcileSplitsForClass, setClassControls } from '$lib/iof/classControls.js';
 	import PersonResultRow from './PersonResultRow.svelte';
 	import TeamResultPanel from './TeamResultPanel.svelte';
 	import ClassControlsPopover from './ClassControlsPopover.svelte';
@@ -67,8 +68,24 @@
 			)
 		)
 			return;
-		const allResults = rl.classResults[classIndex].personResults.flatMap((pr) => pr.results);
+		const classResult = rl.classResults[classIndex];
+		const allResults = classResult.personResults.flatMap((pr) => pr.results);
 		removeControlFromResults(allResults, order, controlCode);
+
+		// Remove the control from class controls so reconciliation uses the updated list
+		const classCtrl = getClassControls(classResult);
+		const newControls = (classCtrl?.controls ?? order).filter((c) => c !== controlCode);
+		setClassControls(classResult, newControls);
+
+		// Re-validate all runners against the updated controls
+		for (const pr of classResult.personResults) {
+			for (const result of pr.results) {
+				const valid = reconcileSplitsForClass(result, newControls);
+				if (!valid && result.status !== 'MissingPunch') result.status = 'MissingPunch';
+				else if (valid && result.status === 'MissingPunch') result.status = 'OK';
+			}
+		}
+
 		recalcPositions(allResults);
 		appState.markDirty();
 	}

--- a/src/lib/components/PersonResultRow.svelte
+++ b/src/lib/components/PersonResultRow.svelte
@@ -3,6 +3,7 @@
 	import { ALL_RESULT_STATUSES } from '$lib/iof/types.js';
 	import { formatTime, parseTime, statusBgClass, statusLabel, recalcPositions, sortPersonResults } from '$lib/utils.js';
 	import { appState } from '$lib/state.svelte.js';
+	import { getClassControls, reconcileSplitsForClass } from '$lib/iof/classControls.js';
 	import SplitTimeList from './SplitTimeList.svelte';
 
 	interface Props {
@@ -72,6 +73,18 @@
 		const rl = appState.resultList;
 		if (!rl) return;
 		const [moved] = rl.classResults[classIndex].personResults.splice(resultIndex, 1);
+
+		// Validate & reconcile splits against the target class's control sequence
+		const targetControls = getClassControls(rl.classResults[targetIndex]);
+		for (const result of moved.results) {
+			if (targetControls) {
+				const valid = reconcileSplitsForClass(result, targetControls.controls);
+				if (!valid && (result.status === 'OK' || result.status === 'Finished')) {
+					result.status = 'MissingPunch';
+				}
+			}
+		}
+
 		rl.classResults[targetIndex].personResults.push(moved);
 		recalcPositions(rl.classResults[classIndex].personResults.map((p) => p.results[0]).filter(Boolean));
 		recalcPositions(rl.classResults[targetIndex].personResults.map((p) => p.results[0]).filter(Boolean));

--- a/src/lib/components/SplitTimeList.svelte
+++ b/src/lib/components/SplitTimeList.svelte
@@ -28,6 +28,9 @@
 
 	const titleId = $derived(`splits-title-${classIndex}-${resultIndex}-${raceResultIndex}-${isTeamMember ? teamIndex : ''}`);
 
+	const additionalCount = $derived(splitTimes.filter((st) => st.status === 'Additional').length);
+	const missingCount = $derived(splitTimes.filter((st) => st.status === 'Missing').length);
+
 	function openDialog() {
 		dialogEl.showModal();
 	}
@@ -126,6 +129,12 @@
 	</svg>
 	{#if splitTimes.length > 0}
 		{splitTimes.length} split{splitTimes.length !== 1 ? 's' : ''}
+		{#if additionalCount > 0}
+			<span title="{additionalCount} additional punch{additionalCount !== 1 ? 'es' : ''} not part of course" class="rounded-full bg-amber-100 px-1 text-[10px] font-semibold text-amber-700 dark:bg-amber-900/40 dark:text-amber-400">+{additionalCount}</span>
+		{/if}
+		{#if missingCount > 0}
+			<span title="{missingCount} missing required control{missingCount !== 1 ? 's' : ''}" class="rounded-full bg-red-100 px-1 text-[10px] font-semibold text-red-600 dark:bg-red-900/40 dark:text-red-400">!{missingCount}</span>
+		{/if}
 	{:else}
 		+ Splits
 	{/if}
@@ -175,9 +184,11 @@
 					</thead>
 					<tbody>
 						{#each splitTimes as st, i (i)}
-							<tr class="group border-b border-gray-100 dark:border-slate-800">
+							<tr class="group border-b border-gray-100 dark:border-slate-800
+								{st.status === 'Additional' ? 'opacity-60' : ''}">
 							<td class="py-3 pr-6 text-gray-400 dark:text-slate-600">{i + 1}</td>
 							<td class="py-3 pr-6">
+								<div class="flex items-center gap-1.5">
 									<input
 										type="text"
 										value={st.controlCode}
@@ -188,6 +199,12 @@
 										}}
 										class="w-16 rounded border border-transparent bg-transparent px-1.5 py-0.5 font-mono hover:border-gray-300 focus:border-indigo-400 focus:bg-indigo-50/50 focus:outline-none dark:hover:border-slate-600 dark:focus:border-indigo-500 dark:focus:bg-indigo-950/20"
 									/>
+									{#if st.status === 'Additional'}
+										<span title="Additional punch — not part of the course" class="cursor-default rounded-full bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold text-amber-700 dark:bg-amber-900/40 dark:text-amber-400">extra</span>
+									{:else if st.status === 'Missing'}
+										<span title="Required control not punched" class="cursor-default rounded-full bg-red-100 px-1.5 py-0.5 text-[10px] font-semibold text-red-600 dark:bg-red-900/40 dark:text-red-400">missing</span>
+									{/if}
+								</div>
 								</td>
 							<td class="py-3 pr-6">
 									<input

--- a/src/lib/components/SplitTimeList.svelte
+++ b/src/lib/components/SplitTimeList.svelte
@@ -30,6 +30,8 @@
 
 	const additionalCount = $derived(splitTimes.filter((st) => st.status === 'Additional').length);
 	const missingCount = $derived(splitTimes.filter((st) => st.status === 'Missing').length);
+	/** Actual punches (OK + Additional); Missing entries are synthesised, not real punches. */
+	const punchedCount = $derived(splitTimes.length - missingCount);
 
 	function openDialog() {
 		dialogEl.showModal();
@@ -118,17 +120,17 @@
 	bind:this={openBtnEl}
 	type="button"
 	onclick={openDialog}
-	aria-label="{splitTimes.length > 0 ? `Edit ${splitTimes.length} splits${personName ? ` for ${personName}` : ''}` : `Add splits${personName ? ` for ${personName}` : ''}`}"
+	aria-label="{punchedCount > 0 ? `Edit ${punchedCount} split${punchedCount !== 1 ? 's' : ''}${personName ? ` for ${personName}` : ''}` : `Add splits${personName ? ` for ${personName}` : ''}`}"
 	class="inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500
-		{splitTimes.length > 0
+		{punchedCount > 0
 			? 'border-indigo-200 bg-indigo-50 text-indigo-700 hover:bg-indigo-100 dark:border-indigo-800 dark:bg-indigo-950/40 dark:text-indigo-300 dark:hover:bg-indigo-900/40'
 			: 'border-dashed border-gray-300 text-gray-400 hover:border-indigo-300 hover:text-indigo-500 dark:border-slate-600 dark:text-slate-500 dark:hover:border-indigo-600 dark:hover:text-indigo-400'}"
 >
 	<svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5" aria-hidden="true">
 		<path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6l4 2m6-2a10 10 0 11-20 0 10 10 0 0120 0z" />
 	</svg>
-	{#if splitTimes.length > 0}
-		{splitTimes.length} split{splitTimes.length !== 1 ? 's' : ''}
+	{#if punchedCount > 0}
+		{punchedCount} split{punchedCount !== 1 ? 's' : ''}
 		{#if additionalCount > 0}
 			<span title="{additionalCount} additional punch{additionalCount !== 1 ? 'es' : ''} not part of course" class="rounded-full bg-amber-100 px-1 text-[10px] font-semibold text-amber-700 dark:bg-amber-900/40 dark:text-amber-400">+{additionalCount}</span>
 		{/if}

--- a/src/lib/iof/classControls.ts
+++ b/src/lib/iof/classControls.ts
@@ -64,6 +64,13 @@ export function reconcileSplitsForClass(
 	if (controls.length === 0) return true;
 
 	const requiredSet = new Set(controls);
+
+	// Drop any synthesised Missing entries for controls no longer required.
+	// (Missing entries have no time, so they are safe to remove when not needed.)
+	result.splitTimes = result.splitTimes.filter(
+		(st) => !(st.status === 'Missing' && !requiredSet.has(st.controlCode))
+	);
+
 	// Index existing splits by control code; keep first occurrence if duplicate
 	const splitByCode = new Map<string, (typeof result.splitTimes)[number]>();
 	for (const st of result.splitTimes) {

--- a/src/lib/iof/classControls.ts
+++ b/src/lib/iof/classControls.ts
@@ -1,0 +1,96 @@
+import type { ClassResult, PersonRaceResult } from './types.js';
+
+export type ControlSource = 'course' | 'splits';
+
+export interface ClassControls {
+	/** Ordered control codes for this class. */
+	controls: string[];
+	/** Whether the sequence came from explicit CourseControl elements or was inferred from split times. */
+	source: ControlSource;
+}
+
+/**
+ * Determine the course controls for a class using the two-option algorithm:
+ *   Option 1 — CourseControl elements in ClassResult/Course (preferred)
+ *   Option 2 — Inferred from the first PersonResult's SplitTimes (fallback)
+ *
+ * Returns null if no controls can be determined.
+ */
+export function getClassControls(cr: ClassResult): ClassControls | null {
+	// Option 1: explicit CourseControl elements
+	for (const course of cr.courses) {
+		const codes = (course.courseControls ?? []).map((cc) => cc.code).filter(Boolean);
+		if (codes.length > 0) return { controls: codes, source: 'course' };
+	}
+
+	// Option 2: infer from first person result that has split times
+	for (const pr of cr.personResults) {
+		for (const result of pr.results) {
+			if (result.splitTimes.length === 0) continue;
+			const controls = result.splitTimes
+				.filter((st) => !st.status || st.status === 'OK' || st.status === 'Missing')
+				.map((st) => st.controlCode)
+				.filter(Boolean);
+			if (controls.length > 0) return { controls, source: 'splits' };
+		}
+	}
+
+	return null;
+}
+
+/**
+ * Persist a new control sequence for a class.
+ * Always writes to courseControls on the first Course element (creating one if needed),
+ * so subsequent calls always use the 'course' source regardless of the original source.
+ */
+export function setClassControls(cr: ClassResult, newControls: string[]): void {
+	if (cr.courses.length === 0) cr.courses = [{}];
+	cr.courses[0].courseControls = newControls.map((code) => ({ code }));
+}
+
+/**
+ * Reconcile a PersonRaceResult against a target class's control sequence after a move.
+ *
+ * - Punches for controls not in the target course are marked Additional.
+ * - Required controls that were punched (have a time) stay OK.
+ * - Required controls that are absent from the competitor's splits get a Missing entry added.
+ *
+ * Returns true if all required controls are present and OK (result is valid).
+ */
+export function reconcileSplitsForClass(
+	result: PersonRaceResult,
+	controls: string[]
+): boolean {
+	if (controls.length === 0) return true;
+
+	const requiredSet = new Set(controls);
+	// Index existing splits by control code; keep first occurrence if duplicate
+	const splitByCode = new Map<string, (typeof result.splitTimes)[number]>();
+	for (const st of result.splitTimes) {
+		if (!splitByCode.has(st.controlCode)) splitByCode.set(st.controlCode, st);
+	}
+
+	// Mark any punched control not in the target course as Additional
+	for (const st of result.splitTimes) {
+		if (!requiredSet.has(st.controlCode)) {
+			st.status = 'Additional';
+		} else if (!st.status || st.status === 'Additional') {
+			// Punched and it IS required — restore to OK
+			st.status = 'OK';
+		}
+	}
+
+	// Ensure every required control has a split entry; add Missing where absent
+	let valid = true;
+	for (const code of controls) {
+		const existing = splitByCode.get(code);
+		if (!existing) {
+			result.splitTimes.push({ controlCode: code, status: 'Missing' });
+			valid = false;
+		} else if (existing.status === 'Missing') {
+			valid = false;
+		}
+	}
+
+	return valid;
+}

--- a/src/lib/iof/parse.ts
+++ b/src/lib/iof/parse.ts
@@ -4,6 +4,7 @@ import {
 	type ClassResult,
 	type Country,
 	type Course,
+	type CourseControl,
 	type EventClass,
 	type EventDate,
 	type IofEvent,
@@ -243,6 +244,20 @@ function parseCourse(el: Element): Course {
 	if (noc !== undefined) course.numberOfControls = noc;
 	const rn = el.getAttribute('raceNumber');
 	if (rn) course.raceNumber = parseInt(rn, 10);
+
+	const ccEls = childEls(el, 'CourseControl');
+	if (ccEls.length > 0) {
+		const controls: CourseControl[] = [];
+		for (const cc of ccEls) {
+			const controlEl = childEl(cc, 'Control');
+			const code = controlEl ? childText(controlEl, 'Code') : undefined;
+			if (!code) continue;
+			const type = cc.getAttribute('type') ?? undefined;
+			controls.push({ code, ...(type ? { type } : {}) });
+		}
+		if (controls.length > 0) course.courseControls = controls;
+	}
+
 	return course;
 }
 

--- a/src/lib/iof/serialize.ts
+++ b/src/lib/iof/serialize.ts
@@ -3,6 +3,7 @@ import {
 	IOF_NAMESPACE,
 	type ClassResult,
 	type Course,
+	type CourseControl,
 	type EventDate,
 	type Organisation,
 	type Person,
@@ -163,6 +164,20 @@ function serializeCourse(doc: Document, course: Course): Element {
 	if (course.climb !== undefined) e.appendChild(textEl(doc, 'Climb', course.climb));
 	if (course.numberOfControls !== undefined)
 		e.appendChild(textEl(doc, 'NumberOfControls', course.numberOfControls));
+	if (course.courseControls) {
+		for (const cc of course.courseControls) {
+			e.appendChild(serializeCourseControl(doc, cc));
+		}
+	}
+	return e;
+}
+
+function serializeCourseControl(doc: Document, cc: CourseControl): Element {
+	const e = el(doc, 'CourseControl');
+	if (cc.type) e.setAttribute('type', cc.type);
+	const controlEl = el(doc, 'Control');
+	controlEl.appendChild(textEl(doc, 'Code', cc.code));
+	e.appendChild(controlEl);
 	return e;
 }
 

--- a/src/lib/iof/types.ts
+++ b/src/lib/iof/types.ts
@@ -84,6 +84,12 @@ export interface SimpleCourse {
 	numberOfControls?: number;
 }
 
+export interface CourseControl {
+	code: string;
+	/** e.g. 'Normal', 'Start', 'Finish', 'ButterflyLoop' */
+	type?: string;
+}
+
 export interface Course {
 	id?: string;
 	name?: string;
@@ -91,6 +97,8 @@ export interface Course {
 	climb?: number;
 	numberOfControls?: number;
 	raceNumber?: number;
+	/** Explicit control sequence from <CourseControl> elements, if present in the source XML. */
+	courseControls?: CourseControl[];
 }
 
 // ---- Result types -------------------------------------------------------

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -132,8 +132,8 @@ export const appState = (() => {
 
 	// Human-readable change log
 	let changeLog = $state<HistoryEntry[]>([]);
-	// The clean state at load time, used to diff the very first edit
-	let initialSnapshot = $state<string | null>(null);
+	// The last committed (clean) state — pushed to past on next markDirty, used for diff labels
+	let committed = $state<string | null>(null);
 
 	let snapshotTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -145,11 +145,13 @@ export const appState = (() => {
 		if (snapshotTimer) clearTimeout(snapshotTimer);
 		snapshotTimer = setTimeout(() => {
 			if (resultList) {
-				const before = past.length > 0 ? past[past.length - 1] : null;
 				const snap = JSON.stringify(resultList);
-				const label = before ? describeChange(before, snap) : 'Edit';
+				if (snap === committed) { snapshotTimer = null; return; }
+				const label = committed ? describeChange(committed, snap) : 'Edit';
 				addLog(label, 'edit');
-				past = [...past.slice(-(MAX_HISTORY - 1)), snap];
+				// Push the pre-batch state so undo can restore to it
+				if (committed !== null) past = [...past.slice(-(MAX_HISTORY - 1)), committed];
+				committed = snap;
 				future = [];
 			}
 			snapshotTimer = null;
@@ -185,7 +187,7 @@ export const appState = (() => {
 			past = [];
 			future = [];
 			rawXml = xml ?? null;
-			initialSnapshot = JSON.stringify(rl);
+			committed = JSON.stringify(rl);
 			addLog(`Loaded: ${rl.event.name}`, 'load');
 		},
 		setParseError(msg: string) {
@@ -198,13 +200,14 @@ export const appState = (() => {
 		},
 		markDirty() {
 			if (!isDirty) {
-				// Snapshot the state just before the first change in a batch
+				// First edit of a new batch: push the pre-mutation committed state to past,
+				// then advance committed to the current (post-mutation) state.
 				if (resultList) {
-					const before = past.length > 0 ? past[past.length - 1] : initialSnapshot;
 					const snap = JSON.stringify(resultList);
-					const label = before ? describeChange(before, snap) : 'Edit';
+					const label = committed ? describeChange(committed, snap) : 'Edit';
 					addLog(label, 'edit');
-					past = [...past.slice(-(MAX_HISTORY - 1)), snap];
+					if (committed !== null) past = [...past.slice(-(MAX_HISTORY - 1)), committed];
+					committed = snap;
 					future = [];
 				}
 				isDirty = true;
@@ -217,21 +220,25 @@ export const appState = (() => {
 		},
 		undo() {
 			if (!resultList || past.length === 0) return;
+			if (snapshotTimer) { clearTimeout(snapshotTimer); snapshotTimer = null; }
 			const current = JSON.stringify(resultList);
 			future = [current, ...future.slice(0, MAX_HISTORY - 1)];
 			const prev = past[past.length - 1];
 			past = past.slice(0, -1);
 			resultList = JSON.parse(prev) as ResultList;
+			committed = prev;
 			isDirty = past.length > 0;
 			addLog('↩ Undo', 'undo');
 		},
 		redo() {
 			if (!resultList || future.length === 0) return;
+			if (snapshotTimer) { clearTimeout(snapshotTimer); snapshotTimer = null; }
 			const current = JSON.stringify(resultList);
 			past = [...past.slice(-(MAX_HISTORY - 1)), current];
 			const next = future[0];
 			future = future.slice(1);
 			resultList = JSON.parse(next) as ResultList;
+			committed = next;
 			isDirty = true;
 			addLog('↪ Redo', 'redo');
 		},
@@ -243,7 +250,7 @@ export const appState = (() => {
 			past = [];
 			future = [];
 			changeLog = [];
-			initialSnapshot = null;
+			committed = null;
 		}
 	};
 })();

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -24,6 +24,10 @@ function describeChange(beforeJson: string, afterJson: string): string {
 			return a.classResults.length > b.classResults.length ? 'Class added' : 'Class removed';
 		}
 
+		// Sort helper for stable person comparison independent of list order
+		const personKey = (p: { person: { name: { given: string; family: string } } }) =>
+			`${p.person.name.family}\0${p.person.name.given}`;
+
 		for (let ci = 0; ci < a.classResults.length; ci++) {
 			const bc = b.classResults[ci];
 			const ac = a.classResults[ci];
@@ -31,20 +35,29 @@ function describeChange(beforeJson: string, afterJson: string): string {
 
 			if (bc.class.name !== ac.class.name) return `Class renamed → "${ac.class.name}"`;
 
-			// Individual
+			// Course controls changed (before person loop so it takes priority)
+			if (JSON.stringify(bc.courses) !== JSON.stringify(ac.courses)) {
+				return `Controls updated — ${ac.class.name}`;
+			}
+
+			// Individual results — sort by name for stable comparison
 			if (bc.personResults.length !== ac.personResults.length) {
 				return ac.personResults.length > bc.personResults.length
 					? `Runner added — ${ac.class.name}`
 					: `Runner removed — ${ac.class.name}`;
 			}
-			for (let ri = 0; ri < ac.personResults.length; ri++) {
-				const bp = bc.personResults[ri];
-				const ap = ac.personResults[ri];
+			const bPersons = [...bc.personResults].sort((x, y) =>
+				personKey(x).localeCompare(personKey(y))
+			);
+			const aPersons = [...ac.personResults].sort((x, y) =>
+				personKey(x).localeCompare(personKey(y))
+			);
+			for (let ri = 0; ri < aPersons.length; ri++) {
+				const bp = bPersons[ri];
+				const ap = aPersons[ri];
 				if (!bp) continue;
-				const aName =
-					`${ap.person.name.given} ${ap.person.name.family}`.trim() || `Runner ${ri + 1}`;
-				const bName =
-					`${bp.person.name.given} ${bp.person.name.family}`.trim() || `Runner ${ri + 1}`;
+				const aName = `${ap.person.name.given} ${ap.person.name.family}`.trim() || `Runner ${ri + 1}`;
+				const bName = `${bp.person.name.given} ${bp.person.name.family}`.trim() || `Runner ${ri + 1}`;
 				if (bName !== aName) return `Renamed: "${aName}" — ${ac.class.name}`;
 				if ((bp.organisation?.name ?? '') !== (ap.organisation?.name ?? ''))
 					return `Club updated — ${aName}`;
@@ -54,14 +67,16 @@ function describeChange(beforeJson: string, afterJson: string): string {
 					if (br.time !== ar.time) return `Time updated — ${aName}`;
 					if (br.status !== ar.status) return `Status → ${ar.status} — ${aName}`;
 					if ((br.bibNumber ?? '') !== (ar.bibNumber ?? '')) return `Bib updated — ${aName}`;
-					if (br.splitTimes.length !== ar.splitTimes.length)
-						return br.splitTimes.length < ar.splitTimes.length
+					const bPunched = br.splitTimes.filter((s) => s.status !== 'Missing');
+					const aPunched = ar.splitTimes.filter((s) => s.status !== 'Missing');
+					if (bPunched.length !== aPunched.length)
+						return bPunched.length < aPunched.length
 							? `Split added — ${aName}`
 							: `Split removed — ${aName}`;
-					for (let si = 0; si < ar.splitTimes.length; si++) {
+					for (let si = 0; si < aPunched.length; si++) {
 						if (
-							br.splitTimes[si]?.time !== ar.splitTimes[si]?.time ||
-							br.splitTimes[si]?.controlCode !== ar.splitTimes[si]?.controlCode
+							bPunched[si]?.time !== aPunched[si]?.time ||
+							bPunched[si]?.controlCode !== aPunched[si]?.controlCode
 						)
 							return `Split updated — ${aName}`;
 					}


### PR DESCRIPTION
## Summary

Implements the two-option algorithm from `class-algorithm.md` for determining which controls belong to a class, adds a controls editor popover, and validates moved competitors against the target class's controls.

## Changes

### Data model
- `types.ts`: Add `CourseControl` interface and `courseControls?: CourseControl[]` to `Course`
- `parse.ts`: Parse `<CourseControl><Control><Code>` from `ClassResult/Course`
- `serialize.ts`: Round-trip `courseControls` back to XML

### Algorithm (`classControls.ts`)
- **Option 1** (preferred): read explicit `CourseControl` elements from `ClassResult/Course`
- **Option 2** (fallback): infer from the first `PersonResult`'s `SplitTime` entries with `status` OK or Missing
- `setClassControls()`: persists edits as `CourseControl` elements (always promotes to Option 1 source after any edit)
- `reconcileSplitsForClass()`: marks punches outside the target course as `Additional`, adds `Missing` entries for absent required controls

### UI — Controls popover (`ClassControlsPopover.svelte`)
- Map-icon button right next to the class name shows the control count (or '?' if unknown)
- Opens a popover with:
  - Source badge: *Explicit (CourseControl)* or *Inferred from splits*
  - Ordered list of editable control code inputs
  - Move-up / move-down / remove per control
  - Add control at bottom (Enter or '+ Add' button)
  - Save / Cancel

### Move validation (`PersonResultRow.svelte`)
- After moving a competitor, `reconcileSplitsForClass` is called against the target class's controls
- If any required control is missing and the result was OK/Finished → status is set to `MissingPunch`

Closes part of #5 (post-merge enhancement)