### PR TITLE
fix: respect control source when serializing CourseControl elements

### DIFF
--- a/src/lib/components/ClassControlsPopover.svelte
+++ b/src/lib/components/ClassControlsPopover.svelte
@@ -66,7 +66,9 @@
 		const rl = appState.resultList;
 		if (!rl) return;
 		const cr = rl.classResults[classIndex];
-		setClassControls(cr, [...editControls]);
+		// Capture source before mutating cr, so setClassControls uses the original strategy.
+		const source = classControls?.source ?? 'splits';
+		setClassControls(cr, [...editControls], source);
 
 		// Re-validate every person in the class against the updated control set
 		for (const pr of cr.personResults) {

--- a/src/lib/components/ClassResultPanel.svelte
+++ b/src/lib/components/ClassResultPanel.svelte
@@ -75,7 +75,7 @@
 		// Remove the control from class controls so reconciliation uses the updated list
 		const classCtrl = getClassControls(classResult);
 		const newControls = (classCtrl?.controls ?? order).filter((c) => c !== controlCode);
-		setClassControls(classResult, newControls);
+		setClassControls(classResult, newControls, classCtrl?.source ?? 'splits');
 
 		// Re-validate all runners against the updated controls
 		for (const pr of classResult.personResults) {

--- a/src/lib/iof/classControls.ts
+++ b/src/lib/iof/classControls.ts
@@ -40,12 +40,26 @@ export function getClassControls(cr: ClassResult): ClassControls | null {
 
 /**
  * Persist a new control sequence for a class.
- * Always writes to courseControls on the first Course element (creating one if needed),
- * so subsequent calls always use the 'course' source regardless of the original source.
+ *
+ * The `source` parameter must match the original source returned by `getClassControls`:
+ * - `'course'`: controls were explicit `CourseControl` elements in the XML → write them
+ *   back to `courseControls` so the serializer round-trips them correctly.
+ * - `'splits'`: controls were inferred from split times → do NOT write `courseControls`
+ *   (leave the field absent) so the serializer never emits `CourseControl` elements for
+ *   this class.  The reconciled split times carry the sequence instead.
  */
-export function setClassControls(cr: ClassResult, newControls: string[]): void {
-	if (cr.courses.length === 0) cr.courses = [{}];
-	cr.courses[0].courseControls = newControls.map((code) => ({ code }));
+export function setClassControls(
+	cr: ClassResult,
+	newControls: string[],
+	source: ControlSource
+): void {
+	if (source === 'course') {
+		if (cr.courses.length === 0) cr.courses = [{}];
+		cr.courses[0].courseControls = newControls.map((code) => ({ code }));
+	} else {
+		// Ensure courseControls is absent so the serializer won't emit CourseControl.
+		if (cr.courses.length > 0) cr.courses[0].courseControls = undefined;
+	}
 }
 
 /**

--- a/src/lib/iof/serialize.ts
+++ b/src/lib/iof/serialize.ts
@@ -155,6 +155,15 @@ function serializeTeamResult(doc: Document, tr: TeamResult): Element {
 	return e;
 }
 
+function serializeCourseControl(doc: Document, cc: CourseControl): Element {
+	const e = el(doc, 'CourseControl');
+	if (cc.type) e.setAttribute('type', cc.type);
+	const controlEl = el(doc, 'Control');
+	controlEl.appendChild(textEl(doc, 'Code', cc.code));
+	e.appendChild(controlEl);
+	return e;
+}
+
 function serializeCourse(doc: Document, course: Course): Element {
 	const e = el(doc, 'Course');
 	if (course.raceNumber !== undefined) e.setAttribute('raceNumber', String(course.raceNumber));
@@ -169,15 +178,6 @@ function serializeCourse(doc: Document, course: Course): Element {
 			e.appendChild(serializeCourseControl(doc, cc));
 		}
 	}
-	return e;
-}
-
-function serializeCourseControl(doc: Document, cc: CourseControl): Element {
-	const e = el(doc, 'CourseControl');
-	if (cc.type) e.setAttribute('type', cc.type);
-	const controlEl = el(doc, 'Control');
-	controlEl.appendChild(textEl(doc, 'Code', cc.code));
-	e.appendChild(controlEl);
 	return e;
 }
 


### PR DESCRIPTION
## Problem

When removing or editing controls for a class whose controls were **inferred from split times** (source = `'splits'`), the validator reported:

```
Element '{...}CourseControl': This element is not expected.
Expected is one of ( {...}Climb, {...}NumberOfControls ).
```

The same error occurred when adding a control to such a class.

## Root cause

`ClassResult/Course` is typed as `SimpleCourse` in the IOF XML 3.0 XSD, which does **not** allow `CourseControl` children. Some result list files do include `CourseControl` elements there (non-standard but supported for round-tripping), so the serializer correctly emits them when `course.courseControls` is set.

The bug was in `setClassControls`: it **always** wrote to `courseControls` regardless of the original source. For splits-sourced classes this caused the serializer to start emitting `CourseControl` elements after the first edit, triggering the XSD error.

## Fix

`setClassControls` now accepts a `source: ControlSource` parameter:

- `source = 'course'` → writes `courseControls` so the serializer round-trips the explicit `CourseControl` elements as before.
- `source = 'splits'` → clears `courseControls` so the serializer never emits `CourseControl`; the reconciled split times carry the sequence instead.

Both call sites (`ClassControlsPopover` and `ClassResultPanel`) capture the source **before** the mutation and pass it through.