### PR TITLE
feat: show imported file name in event header

### DIFF
--- a/src/lib/components/EventHeader.svelte
+++ b/src/lib/components/EventHeader.svelte
@@ -27,6 +27,17 @@
 			/>
 
 			<div class="mt-2 flex flex-wrap items-center gap-2 text-sm text-gray-500 dark:text-slate-400">
+				{#if appState.fileName}
+					<div class="flex min-w-0 items-center gap-1" title={appState.fileName}>
+						<svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+							<path stroke-linecap="round" stroke-linejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+						</svg>
+						<span class="truncate font-mono text-xs">{appState.fileName}</span>
+					</div>
+					{#if event.startTime || event.endTime}
+						<span class="text-gray-300 dark:text-slate-600" aria-hidden="true">·</span>
+					{/if}
+				{/if}
 				{#if event.startTime}
 					<div class="flex items-center gap-1">
 						<svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">

--- a/src/lib/components/FileLoader.svelte
+++ b/src/lib/components/FileLoader.svelte
@@ -12,9 +12,9 @@
 	let inputEl: HTMLInputElement;
 	let dragOver = $state(false);
 
-	function parseXml(xml: string) {
+	function parseXml(xml: string, name: string) {
 		try {
-			appState.setResultList(parseResultList(xml), xml);
+			appState.setResultList(parseResultList(xml), xml, name);
 		} catch (e) {
 			appState.setParseError(e instanceof Error ? e.message : String(e));
 		}
@@ -55,7 +55,9 @@
 						appState.setParseError('No .xml file found inside the zip archive.');
 						return;
 					}
-					parseXml(decodeXmlBytes(entries[xmlKey]));
+					// Show the inner XML's own name — more descriptive than the zip's.
+					const innerName = xmlKey.split('/').pop() || xmlKey;
+					parseXml(decodeXmlBytes(entries[xmlKey]), `${file.name} › ${innerName}`);
 				} catch (e) {
 					appState.setParseError(e instanceof Error ? e.message : String(e));
 				}
@@ -64,7 +66,7 @@
 			reader.readAsArrayBuffer(file);
 		} else {
 			reader.onload = () => {
-				parseXml(decodeXmlBytes(new Uint8Array(reader.result as ArrayBuffer)));
+				parseXml(decodeXmlBytes(new Uint8Array(reader.result as ArrayBuffer)), file.name);
 				inputEl.value = '';
 			};
 			reader.readAsArrayBuffer(file);

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -152,6 +152,7 @@ export const appState = (() => {
 	let parseError = $state<string | null>(null);
 	let isDirty = $state(false);
 	let rawXml = $state<string | null>(null);
+	let fileName = $state<string | null>(null);
 
 	// Undo/redo stacks hold serialized snapshots
 	let past = $state<string[]>([]); // [oldest, ..., most recent before current]
@@ -198,6 +199,9 @@ export const appState = (() => {
 		get rawXml() {
 			return rawXml;
 		},
+		get fileName() {
+			return fileName;
+		},
 		get canUndo() {
 			return past.length > 0;
 		},
@@ -207,21 +211,23 @@ export const appState = (() => {
 		get changeLog(): HistoryEntry[] {
 			return changeLog;
 		},
-		setResultList(rl: ResultList, xml?: string) {
+		setResultList(rl: ResultList, xml?: string, name?: string) {
 			resultList = rl;
 			parseError = null;
 			isDirty = false;
 			past = [];
 			future = [];
 			rawXml = xml ?? null;
+			fileName = name ?? null;
 			committed = JSON.stringify(rl);
-			addLog(`Loaded: ${rl.event.name}`, 'load');
+			addLog(`Loaded: ${rl.event.name}${name ? ` (${name})` : ''}`, 'load');
 		},
 		setParseError(msg: string) {
 			parseError = msg;
 			resultList = null;
 			isDirty = false;
 			rawXml = null;
+			fileName = null;
 			past = [];
 			future = [];
 		},
@@ -274,6 +280,7 @@ export const appState = (() => {
 			parseError = null;
 			isDirty = false;
 			rawXml = null;
+			fileName = null;
 			past = [];
 			future = [];
 			changeLog = [];


### PR DESCRIPTION
## Summary

After loading a result list there was no on-screen indication of which file it came from — you had to inspect the XML to tell two lists apart. The app now remembers the source file name and shows it.

- `appState` stores a `fileName`, set in `setResultList` and cleared in `clear`/`setParseError`.
- `FileLoader` passes the picked file's name; for zips it shows `archive.zip › inner.xml` (the inner XML name is more descriptive than the archive's).
- `EventHeader` renders the name (monospace, truncated, full value on hover) next to the event dates.
- The "Loaded" changelog entry now includes the file name too.

## Test plan

- [x] `npm test` — 45/45 pass.
- [x] `npm run check` clean (one pre-existing a11y warning, unrelated).
- [x] `npm run lint` clean.
- [ ] Load a plain `.xml` and a `.zip` in dev and confirm the name shows correctly in the header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)